### PR TITLE
Update sha256 hash on formula to resolve installation failure

### DIFF
--- a/fvm.rb
+++ b/fvm.rb
@@ -4,7 +4,7 @@ class Fvm < Formula
   desc "Simple cli to manage Flutter SDK versions per project"
   homepage "https://github.com/fluttertools/fvm"
   url "https://github.com/fluttertools/fvm/archive/2.4.1.tar.gz"
-  sha256 "578ddc4cc63656938afbfa971e08325d22af1ce4487cb264753dd829e419646b"
+  sha256 "a79559e6a0a2b0ef9f0ac15223b40b630899422eb65e032ccd194492228197a3"
   license "MIT"
 
   depends_on "dart-lang/dart/dart" => :build


### PR DESCRIPTION
This PR resolves installation problem (also reported in https://github.com/leoafarias/homebrew-fvm/issues/6).

I'm not sure why, but the archive of `578ddc4` hash does not exist in fluttertools/fvm, so I got following installation error.

```
brew install fvm

==> Downloading https://storage.googleapis.com/dart-archive/channels/stable/release/2.18.7/sdk/dartsdk-macos-arm64-release.zip
######################################################################## 100.0%
==> Downloading https://github.com/fluttertools/fvm/archive/2.4.1.tar.gz
==> Downloading from https://codeload.github.com/fluttertools/fvm/tar.gz/refs/tags/2.4.1
##O#-#
Error: fvm: SHA256 mismatch
Expected: 578ddc4cc63656938afbfa971e08325d22af1ce4487cb264753dd829e419646b
  Actual: a79559e6a0a2b0ef9f0ac15223b40b630899422eb65e032ccd194492228197a3
    File: /Library/Caches/Homebrew/downloads/54b77538c3b1241d7203cf322d4c29f344917cfacab6f1f19203cff6dc2390e4--fvm-2.4.1.tar.gz
To retry an incomplete download, remove the file above.
```