### PR TITLE
Fix audit/style offenses in fvm formula

### DIFF
--- a/fvm.rb
+++ b/fvm.rb
@@ -3,7 +3,7 @@ require "yaml"
 class Fvm < Formula
   desc "Simple cli to manage Flutter SDK versions per project"
   homepage "https://github.com/leoafarias/fvm"
-  url "https://github.com/leoafarias/fvm/archive/4.1.0.tar.gz"
+  url "https://github.com/leoafarias/fvm/archive/refs/tags/4.1.0.tar.gz"
   sha256 "44f24d6bef61f78fef509415bc8974fcd60c5ffe937f9a4d9b17fe26c55670a2"
   license "MIT"
 
@@ -35,12 +35,12 @@ class Fvm < Formula
     end
 
     ENV["PUB_ENVIRONMENT"] = "homebrew:fvm"
-    
+
     # Adjust paths to use the vendored Dart SDK
     dart = libexec/"bin/dart"
-    
+
     system dart, "pub", "get"
-    
+
     if Hardware::CPU.is_64_bit?
       _install_native_executable(dart)
     else
@@ -56,7 +56,7 @@ class Fvm < Formula
   private
 
   def _version
-    @_version ||= YAML.safe_load(File.read("pubspec.yaml"))["version"]
+    @_version ||= YAML.safe_load_file("pubspec.yaml")["version"]
   end
 
   def _install_native_executable(dart)
@@ -71,7 +71,7 @@ class Fvm < Formula
            "-o", "main.dart.app.snapshot",
            "bin/main.dart"
     lib.install "main.dart.app.snapshot"
-    
+
     cp dart, lib
 
     (bin/"fvm").write <<~SH


### PR DESCRIPTION
## What

Fixes the `brew audit`/`brew style` offenses reported for the active `fvm.rb` formula.

## Offenses fixed

```
FormulaAudit/Urls          — use refs/tags/ form for the GitHub archive URL
Style/YAMLFileRead         — use YAML.safe_load_file instead of safe_load(File.read)
Layout/TrailingWhitespace  — remove trailing whitespace
```

## Safety

The URL change is purely a canonicalization — the `refs/tags/` form resolves to the **identical tarball**, so the checksum is unchanged. Verified:

```
curl -sL https://github.com/leoafarias/fvm/archive/refs/tags/4.1.0.tar.gz | shasum -a 256
# => 44f24d6bef61f78fef509415bc8974fcd60c5ffe937f9a4d9b17fe26c55670a2  (matches existing sha256)
```

## Scope

Intentionally scoped to the active `fvm.rb` only — the versioned `fvm@*.rb` files are left untouched to keep this PR small and reviewable.